### PR TITLE
Adding hl Groups for render-markdown.nvim

### DIFF
--- a/lua/zitchdog/groups/editor.lua
+++ b/lua/zitchdog/groups/editor.lua
@@ -218,6 +218,9 @@ local function createEditorGroup(palette, zitch)
 
     CopilotSuggestion = { bg = "NONE", fg = palette.mulberry },
     CopilotAnnotation = { bg = "NONE", fg = palette.slate, bold = true },
+
+    RenderMarkdownCode = zitch.Green,
+    RenderMarkdownCodeInline = zitch.Green,
   }
 end
 


### PR DESCRIPTION
Hey 👋🏽 
I use the [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) plugin for notetaking. I noticed that code blocks hl group inside markdown ft while using the render-markdown plugin are different. The code blocks were unreadable. 

![image](https://github.com/user-attachments/assets/1762497b-52c5-47c9-af59-149768cb5128)

I've copied over the `markdownCode` group palette for both `RenderMarkdownCode` and `RenderMarkdownCodeInline`. 

I am not sure if this is the right palette choice for this theme, so feel free to make any changes, but I was hoping to include these groups in the theme by default so that render-markdown.nvim looks good out of the box with this theme.

Here's what is looks like with the changes applied

![image](https://github.com/user-attachments/assets/2ad7068c-7b63-4441-a02c-3f0019852ae4)
